### PR TITLE
Harden GUI startup and worker lifecycle

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,16 @@
+# Suggestions for PressMage Improvements
+
+## Graceful shutdown of the worker thread
+The `BotWorker.run` loop runs indefinitely and only yields via `time.sleep`, even after `stop()` is called; closing the window simply flips `_running` to `False` without breaking the loop or stopping the `QThread`. Adding a request flag that exits the loop and invoking `thread.quit()/thread.wait()` from `MainWindow.closeEvent` would avoid dangling background threads during shutdown and make unit testing easier.【F:PressMage.py†L320-L371】【F:PressMage.py†L440-L458】【F:PressMage.py†L495-L512】【F:PressMage.py†L994-L1000】
+
+## Avoid recomputing edge templates each iteration
+When Canny-based matching is enabled, each cycle recomputes `cv2.Canny` for every template, which is expensive. Caching an edge version of each template (e.g., prepared when `set_params` is called) would substantially cut CPU usage inside the hot loop.【F:PressMage.py†L346-L407】
+
+## User-friendly handling of missing Windows-only dependencies
+`run_gui_app` imports many Windows-specific modules unconditionally. On non-Windows hosts this raises `ImportError` before the app can explain the requirement. Wrapping the imports in platform checks and surfacing a clear dialog would improve diagnostics and allow the CLI/core parts to run cross-platform.【F:PressMage.py†L109-L132】
+
+## Enrich error logging from the worker loop
+The worker currently logs only the exception message, losing stack details that would help diagnose detection issues. Capturing `traceback.format_exc()` alongside the message or routing errors through the existing colored log helper would make support incidents easier to investigate.【F:PressMage.py†L448-L451】
+
+## Extend coverage of the queue engine tests
+The embedded unit tests exercise only two happy paths. Adding cases for deduplication, invalid directions, and `pending_count` would protect the core input queue against regressions as timing rules evolve.【F:PressMage.py†L18-L104】【F:PressMage.py†L1009-L1050】

--- a/PressMage.py
+++ b/PressMage.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import sys
 import time
 from dataclasses import dataclass
+import threading
 from typing import Callable, Deque, Dict, List, Optional, Tuple
 from collections import deque
 
@@ -108,6 +109,31 @@ class ArrowQueueEngine:
 
 def run_gui_app() -> None:
     """Импорт и запуск GUI."""
+    if sys.platform != "win32":
+        raise RuntimeError("GUI поддерживается только на Windows. Используйте флаг --test для запуска тестов.")
+
+    import importlib.util
+
+    required = [
+        "ctypes",
+        "winsound",
+        "psutil",
+        "numpy",
+        "cv2",
+        "PIL.ImageGrab",
+        "pyautogui",
+        "win32gui",
+        "win32process",
+        "win32con",
+        "PyQt5",
+    ]
+    missing = [name for name in required if importlib.util.find_spec(name) is None]
+    if missing:
+        raise RuntimeError(
+            "Для запуска GUI отсутствуют зависимости: " + ", ".join(sorted(missing)) +
+            ". Установите их и повторите попытку."
+        )
+
     import os
     import ctypes
     from ctypes import wintypes
@@ -161,7 +187,10 @@ def run_gui_app() -> None:
             return False
 
     # ---------- NMS (простая по центрам) ----------
-    def nms_detections(dets: List[Tuple[int,int,int,int,str,float]], radius: int = 12) -> List[Tuple[int,int,int,int,str,float]]:
+    def nms_detections(
+        dets: List[Tuple[int, int, int, int, str, float]],
+        radius: int = 12,
+    ) -> List[Tuple[int, int, int, int, str, float]]:
         dets = sorted(dets, key=lambda d: d[5], reverse=True)
         picked: List[Tuple[int,int,int,int,str,float]] = []
         centers: List[Tuple[float,float]] = []
@@ -324,6 +353,7 @@ def run_gui_app() -> None:
             super().__init__()
             self._running = False
             self._paused = False
+            self._stop_event = threading.Event()
             self._sessions = 0
             self._arrows_found = 0
             self._keys_pressed = 0
@@ -357,26 +387,31 @@ def run_gui_app() -> None:
         def stop(self):
             self._running = False; self._paused = False; self.log_sig.emit("Поток остановлен", "info")
 
+        def shutdown(self):
+            self._running = False
+            self._paused = False
+            self._stop_event.set()
+
         def toggle_pause(self):
             self._paused = not self._paused
             self.log_sig.emit("Пауза: ВКЛ" if self._paused else "Пауза: ВЫКЛ",
                               "warning" if self._paused else "success")
 
         def run(self):
-            while True:
+            while not self._stop_event.is_set():
                 if not self._running or self._paused:
-                    time.sleep(0.05); continue
+                    self._stop_event.wait(0.05); continue
                 try:
                     proc_name = str(self.params.get("process_name", ""))
                     hwnd = get_window_by_process(proc_name)
                     if not hwnd:
-                        time.sleep(0.3); continue
+                        self._stop_event.wait(0.3); continue
                     geom = get_window_geometry(hwnd)
                     if not geom:
-                        time.sleep(0.3); continue
+                        self._stop_event.wait(0.3); continue
                     l, t, r, b = geom
                     if r - l <= 0 or b - t <= 0:
-                        time.sleep(0.2); continue
+                        self._stop_event.wait(0.2); continue
 
                     roi = (
                         l + int(self.params.get("roi_left", 0)),
@@ -442,10 +477,12 @@ def run_gui_app() -> None:
                         self.stats_sig.emit(self._arrows_found, len(self.engine.pressed_log), self._sessions)
                         self.progress_sig.emit()
 
-                    time.sleep(float(self.params.get("loop_delay", 0.10)))
+                    self._stop_event.wait(float(self.params.get("loop_delay", 0.10)))
                 except Exception as e:
                     self.log_sig.emit(f"Ошибка в цикле: {e}", "error")
-                    time.sleep(0.2)
+                    self._stop_event.wait(0.2)
+
+            self.log_sig.emit("Рабочий поток завершён", "info")
 
         def _on_engine_press(self, direction: str, when: float):
             key = str(self.params.get(f"key_{direction}", direction))
@@ -576,10 +613,12 @@ def run_gui_app() -> None:
             btn_clear = QPushButton('Очистить логи'); btn_clear.clicked.connect(lambda: self.log_text.clear()); vb3.addWidget(btn_clear)
             v.addWidget(gb3)
 
-            info = QLabel('• Очередь: жмём в порядке появления.
-• Две задержки действуют вместе: между нажатиями и после появления.
-• ROI выбирается ТОЛЬКО внутри окна игры.
-• Живой оверлей Ctrl+F4: подсветка детекций прямо в игре.')
+            info = QLabel(
+                "• Очередь: жмём в порядке появления.\n"
+                "• Две задержки действуют вместе: между нажатиями и после появления.\n"
+                "• ROI выбирается ТОЛЬКО внутри окна игры.\n"
+                "• Живой оверлей Ctrl+F4: подсветка детекций прямо в игре."
+            )
             info.setStyleSheet("background:#e8f4f8;padding:10px;border-radius:8px;border:2px solid #b3e0f2;font-weight:bold;")
             v.addWidget(info)
             return w
@@ -991,6 +1030,9 @@ def run_gui_app() -> None:
                 self._save_settings()
                 self.worker.stop()
                 self.hotkey_filter.unregister()
+                self.worker.shutdown()
+                self.thread.quit()
+                self.thread.wait(1500)
             finally:
                 event.accept()
 


### PR DESCRIPTION
## Summary
- prevent launching the GUI on non-Windows hosts and surface missing dependency diagnostics before import time
- add a stop event to BotWorker so the detection thread can exit cleanly and log its shutdown
- ensure the main window shuts the worker thread down before quitting to avoid hanging threads

## Testing
- python -m compileall PressMage.py

------
https://chatgpt.com/codex/tasks/task_e_68d68b0ff32083309131c6bc1aee2283